### PR TITLE
Fix for newer agda version

### DIFF
--- a/Syntax/Syntax.agda
+++ b/Syntax/Syntax.agda
@@ -322,7 +322,7 @@ weakenDT₁ = weakenDT Ø
 weakenDecentCtxMor : {Γ₁ Γ₂ : RawCtx} {f : CtxMor Raw Γ₁ Γ₂} →
                      (A : U) → DecentCtxMor f →
                      DecentCtxMor (Vec.map (weaken₁ A) f)
-weakenDecentCtxMor {Γ₂ = Ø}      {f}     A p        = tt
+weakenDecentCtxMor {Γ₂ = Ø}      {[]}    A p        = tt
 weakenDecentCtxMor {Γ₂ = x ∷ Γ₂} {t ∷ f} A (p , ps) =
   (weakenDO₁ A p , weakenDecentCtxMor A ps)
 

--- a/Syntax/SyntaxRaw.agda
+++ b/Syntax/SyntaxRaw.agda
@@ -5,6 +5,7 @@ open import Data.Empty
 open import Data.Unit as Unit
 open import Data.Nat
 open import Data.List as List renaming ([] to Ø; [_] to [_]L)
+open import Data.List.Properties using (++-monoid)
 open import NonEmptyList as NList
 open import Data.Vec as Vec hiding ([_]; _++_)
 open import Data.Product as Prod
@@ -67,7 +68,7 @@ RawCtx : Set
 RawCtx = Ctx U
 
 instance ctx-monoid : Monoid _ _
-ctx-monoid = List.monoid U
+ctx-monoid = ++-monoid U
 
 RawVar : RawCtx → U → Set
 RawVar = Var
@@ -76,7 +77,7 @@ TyCtx : Set
 TyCtx = Ctx RawCtx
 
 instance tyctx-monoid : Monoid _ _
-tyctx-monoid = List.monoid RawCtx
+tyctx-monoid = ++-monoid RawCtx
 
 TyVar : TyCtx → RawCtx → Set
 TyVar = Var


### PR DESCRIPTION
I made some fixes to compile your code for agda 2.6.0.1 and the StdLib 1.1
- Data.List.monoid is now Data.List.Properties.++-monoid
- Agda couldn't typecheck `weakenDecentCtxMor` for the case wher `Γ₂` is empty.  I had to give the pattern `[]` for `f` to make it type check.